### PR TITLE
Spacing issue for ghost variables

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -1026,7 +1026,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
     public void visit(JmlGhostStmt n, Void arg) {
         printOrphanCommentsBeforeThisChildNode(n);
         wrapInJmlIfNeeded(() -> {
-            printer.print("ghost");
+            printer.print("ghost ");
             n.getStatement().accept(this, arg);
             printer.print("\n");
         });


### PR DESCRIPTION
Ghost JML code was missing a space.

Example:
```java
public class Mult {
    public int mult (int x, int y){
	//@ ghost int oldx = x;
        return 1
    }
}

```
Was printed as:
```java
public class Mult {
    public int mult (int x, int y){
	//@ ghostint oldx = x;
        return 1
    }
}

```
